### PR TITLE
Clear images after upload

### DIFF
--- a/src/pages/UploadPage.jsx
+++ b/src/pages/UploadPage.jsx
@@ -29,6 +29,9 @@ export default function UploadPage() {
     const files = event.target.files;
     const newImages = await Promise.all(Array.from(files).map(loadImage))
     setImages([ ...images, ...newImages ])
+
+    // reset to allow new images to be uploaded
+    event.target.value = null
   }
 
   const onRemove = useCallback((index) => {


### PR DESCRIPTION
After adding images to the in-memory state, I clear the input field. If not clearing this, the input will automatically ignore any requests to add an image that has already been added, for example, if it has been removed from the list once.